### PR TITLE
Create short links for battles

### DIFF
--- a/outputfunctions.php
+++ b/outputfunctions.php
@@ -298,16 +298,21 @@ function probgraph ($num_times, $force, $units, $lost, $cost, $median, $stdev1, 
 	return $result;
 }
 
+
 //creates the URL link for running the same battle with units and options set
 function scenariolink ($type) {
-	global $pageurl, $forces;
+	global $pageurl, $forces, $url;
 	$url=$pageurl.'?';
 	foreach ($_REQUEST as $key => $value) { if ($key !== 'pbem') $url.="$key=$value&";
 	};
 	$url.='pbem=';
-	$link='<a href="'.$url.'">Link to or bookmark this scenario</a>.';
+	$foo = $url;
+	$newname = time('U').md5($pageurl).'.html';
+	$domainname = '';
+	$customdir = 'b';
+	file_put_contents($customdir.'/'.$newname,"<meta http-equiv='refresh' content='0;url=".$domainname."/index.php".$foo."' />");
+	print('<input type="text" size="75" value="'.$domainname.'/'.$customdir.'/'.$newname.'" ><br /><br />');//currently unknown why this double-displays at the top, and removes the bottom one
 #	if ($type='mail') $link .= ' <span class="noshow">Full address: '.$url.'</span>';
-	return $link;
 }
 
 //keeps track of battle result(s) and displays them...this is the main function called by index.php file to display results
@@ -505,4 +510,7 @@ function nobattle () {
 	<li>Attacker has combination of artillery and advanced artillery, subs and super subs, fighters and jet fighters, or bombers and heavy bombers.</li>
 	</ul>';
 }
+
+
 ?>
+


### PR DESCRIPTION
This proposed update creates short links and prints the short links. The $domainname needs to be declared on line 311 and the $customdir needs to be manually created (and optionally changed).  This is for easier sharing of battles so the links do not seem quite as spammy.

Feel free to view the live example at https://prts.cr/calc/ .  This example is planned to be removed after PR is accepted/rejected.

This update is intended to be used with a cronjob similar to `0 0 * * * find /public_html/calc/b -depth -type f -atime +10 -delete` which will delete the redirect webpages (in the `b` directory) after they have not been accessed for 10 days, and will run on the first of the month. Keep in mind, everytime the redirect webpage is loaded, it will create a new shortlink, so expect quite a few redirects per actual battle. 

I am seeing 780B per webpage which is nominal if they are deleted after 10 (or more days) but will possibly be burdensome if they are never deleted.

It is currently unknown why the bottom link has moved to the top.